### PR TITLE
Fix in_qmk_firmware for Python 3.5

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -33,7 +33,7 @@ def in_qmk_firmware():
     while len(cur_dir.parents) > 0:
         found_bin = cur_dir / 'bin' / 'qmk'
         if found_bin.is_file():
-            command = [found_bin, '--version']
+            command = [found_bin.as_posix(), '--version']
             result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
             if result.returncode == 0:


### PR DESCRIPTION
When running the global cli within qmk/qmk_base_container#5, it produces the following output:
```console
Traceback (most recent call last):
  File "/usr/local/bin/qmk", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.5/dist-packages/qmk_cli/script_qmk.py", line 67, in main
    qmk_firmware = find_qmk_firmware()
  File "/usr/local/lib/python3.5/dist-packages/qmk_cli/script_qmk.py", line 54, in find_qmk_firmware
    if in_qmk_firmware():
  File "/usr/local/lib/python3.5/dist-packages/qmk_cli/script_qmk.py", line 37, in in_qmk_firmware
    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python3.5/subprocess.py", line 383, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.5/subprocess.py", line 676, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/subprocess.py", line 1205, in _execute_child
    executable = os.fsencode(executable)
  File "/usr/lib/python3.5/os.py", line 862, in fsencode
    raise TypeError("expect bytes or str, not %s" % type(filename).__name__)
TypeError: expect bytes or str, not PosixPath
```