### PR TITLE
Subcommands use dashes instead of underscores.

### DIFF
--- a/milc.py
+++ b/milc.py
@@ -599,7 +599,7 @@ class MILC(object):
             self.add_subparsers()
 
         if not name:
-            name = handler.__name__
+            name = handler.__name__.replace('_', '-')
 
         self.acquire_lock()
         kwargs['help'] = description

--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -3,7 +3,6 @@
 
 This program can be run from anywhere, with or without a qmk_firmware repository. If a qmk_firmware repository can be located we will use that to augment our available subcommands.
 
-FIXME(skullydazed/anyone): --help shows underscores where we want dashes in subcommands (EG json_keymap instead of json-keymap)
 TODO(skullydazed/anyone): Need a way to filter some subcommands from --help (EG `qmk hello`)
 """
 import argparse


### PR DESCRIPTION
Based off of the `FIXME(skullydazed/anyone): --help shows underscores where we want dashes in subcommands (EG json_keymap instead of json-keymap)`. I assume this is what was wanted. Couldn't interpret it any other way, so if it is incorrect, please do tell me, and I will change it accordingly.