### PR TITLE
Fix No such file or directory: 'C:\\dev\\null'

### DIFF
--- a/milc.py
+++ b/milc.py
@@ -39,7 +39,7 @@ import colorama
 from appdirs import user_config_dir
 
 # Disable logging until we can configure it how the user wants
-logging.basicConfig(filename='/dev/null')
+logging.basicConfig(stream=os.devnull)
 
 # Log Level Representations
 EMOJI_LOGLEVELS = {


### PR DESCRIPTION
When rigging up some initial CI process, It was noticed that on Windows it would error out.

```console
Traceback (most recent call last):
  File "./qmk", line 4, in <module>
    import qmk_cli.script_qmk
  File "C:\Users\travis\build\zvecr\qmk_cli\qmk_cli\script_qmk.py", line 16, in <module>
    import milc
  File "C:\Users\travis\build\zvecr\qmk_cli\milc.py", line 42, in <module>
    logging.basicConfig(filename='/dev/null')
  File "C:\Python\lib\logging\__init__.py", line 1973, in basicConfig
    h = FileHandler(filename, mode)
  File "C:\Python\lib\logging\__init__.py", line 1143, in __init__
    StreamHandler.__init__(self, self._open())
  File "C:\Python\lib\logging\__init__.py", line 1172, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\dev\\null'
```

While im guessing MSYS is the target platform, Ive updated the init path to a more portable solution.