### PR TITLE
Protect against empty QMK_HOME folder

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -82,10 +82,12 @@ def main():
     if qmk_firmware.exists():
         os.chdir(str(qmk_firmware))
         sys.path.append(str(qmk_firmware / 'lib' / 'python'))
-        try:
-            import qmk.cli
-        except ImportError:
-            pass # Ingore as this might folder might not be set up correctly
+            try:
+                import qmk.cli
+            except ImportError:
+                print('Error: %s is too old or not set up correctly!' % qmk_firmware)
+                print('Please update it or remove it completely before continuing.')
+                sys.exit(1)
 
     # Call the entrypoint
     milc.cli()

--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -82,12 +82,12 @@ def main():
     if qmk_firmware.exists():
         os.chdir(str(qmk_firmware))
         sys.path.append(str(qmk_firmware / 'lib' / 'python'))
-            try:
-                import qmk.cli
-            except ImportError:
-                print('Error: %s is too old or not set up correctly!' % qmk_firmware)
-                print('Please update it or remove it completely before continuing.')
-                sys.exit(1)
+        try:
+            import qmk.cli
+        except ImportError:
+            print('Error: %s is too old or not set up correctly!' % qmk_firmware)
+            print('Please update it or remove it completely before continuing.')
+            sys.exit(1)
 
     # Call the entrypoint
     milc.cli()

--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -79,10 +79,13 @@ def main():
     # Import the subcommand modules
     import qmk_cli.subcommands
 
-    if qmk_firmware.exists() and os.listdir(qmk_firmware):
+    if qmk_firmware.exists():
         os.chdir(str(qmk_firmware))
         sys.path.append(str(qmk_firmware / 'lib' / 'python'))
-        import qmk.cli
+        try:
+            import qmk.cli
+        except ImportError:
+            pass # Ingore as this might folder might not be set up correctly
 
     # Call the entrypoint
     milc.cli()

--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -79,7 +79,7 @@ def main():
     # Import the subcommand modules
     import qmk_cli.subcommands
 
-    if qmk_firmware.exists():
+    if qmk_firmware.exists() and os.listdir(qmk_firmware):
         os.chdir(str(qmk_firmware))
         sys.path.append(str(qmk_firmware / 'lib' / 'python'))
         import qmk.cli

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -24,7 +24,7 @@ def setup(cli):
     qmk_firmware = Path(cli.args.destination)
 
     # Check on qmk_firmware, and if it doesn't exist offer to check it out.
-    if qmk_firmware.exists():
+    if qmk_firmware.exists() and os.listdir(qmk_firmware):
         cli.log.info('Found qmk_firmware at %s.', str(qmk_firmware))
     else:
         cli.log.error('qmk_firmware not found!')

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -24,7 +24,7 @@ def setup(cli):
     qmk_firmware = Path(cli.args.destination)
 
     # Check on qmk_firmware, and if it doesn't exist offer to check it out.
-    if qmk_firmware.exists() and os.listdir(qmk_firmware):
+    if (qmk_firmware / 'Makefile').exists():
         cli.log.info('Found qmk_firmware at %s.', str(qmk_firmware))
     else:
         cli.log.error('qmk_firmware not found!')


### PR DESCRIPTION
Attempting `qmk setup` to a non standard location, it was spitting out the following error:
```console
Traceback (most recent call last):
  File "/home/zvecr/.local/bin/qmk", line 10, in <module>
    sys.exit(main())
  File "/home/zvecr/.local/lib/python3.7/site-packages/qmk_cli/script_qmk.py", line 85, in main
    import qmk.cli
ModuleNotFoundError: No module named 'qmk'
```

Took a while to realise it was due to the target folder existing, but empty. Removing the empty folder worked, but working round that is potentially a little friendlier to end users.

This also fixes `qmk setup zvecr/qmk_firmware .` to install directly to the current directory.