### PR TITLE
Add warning message for MSYS users

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from functools import lru_cache
 from pathlib import Path
+import platform
 
 import milc
 
@@ -68,6 +69,11 @@ def main():
     if sys.version_info < (3, 6):
         print('Warning: Your Python version is out of date! Some subcommands may not work!')
         print('Please upgrade to Python 3.6 or later.')
+
+    if 'windows' in platform.platform().lower():
+        if 'mingw64' not in sys.executable or 'mingw64' not in os.environ.get('MSYSTEM_PREFIX', ''):
+            print('Warning: It seems you are not using the MINGW64 terminal.')
+            print('While the MSYS one can work, too, we recommend/support you start "MSYS2 MinGW 64-bit".\n')
 
     # Environment setup
     import qmk_cli


### PR DESCRIPTION
Warn MSYS2 users that the are not in the MINGW64 shell.
This does not affect WSL or other platforms.

This is just a warning, so already set up environments can be used.