### PR TITLE
improve the qmk setup flow

### DIFF
--- a/qmk_cli/git.py
+++ b/qmk_cli/git.py
@@ -28,5 +28,5 @@ def clone(url, destination, branch):
         cli.log.error('git clone exited %d', p.returncode)
         return False
     else:
-        cli.log.info('Successfully cloned %s to %s!', cli.args.fork, cli.args.destination)
+        cli.log.info('Successfully cloned %s to %s!', url, destination)
         return True

--- a/qmk_cli/git.py
+++ b/qmk_cli/git.py
@@ -26,7 +26,6 @@ def clone(url, destination, branch):
 
     if p.returncode != 0:
         cli.log.error('git clone exited %d', p.returncode)
-        return False
     else:
         cli.log.info('Successfully cloned %s to %s!', url, destination)
-        return True
+    return p.returncode

--- a/qmk_cli/git.py
+++ b/qmk_cli/git.py
@@ -9,7 +9,7 @@ default_fork = 'qmk/' + default_repo
 default_branch = 'master'
 
 
-def clone(url, destination, branch):
+def git_clone(url, destination, branch):
     git_clone = [
         'git',
         'clone',
@@ -20,7 +20,7 @@ def clone(url, destination, branch):
     ]
     cli.log.debug('Git clone command: %s', git_clone)
 
-    with subprocess.Popen(git_clone, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, bufsize=1, universal_newlines=True) as p:
+    with subprocess.Popen(git_clone, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, bufsize=1, universal_newlines=True, encoding='utf-8') as p:
         for line in p.stdout:
             print(line, end='')
 
@@ -28,4 +28,5 @@ def clone(url, destination, branch):
         cli.log.error('git clone exited %d', p.returncode)
     else:
         cli.log.info('Successfully cloned %s to %s!', url, destination)
+
     return p.returncode

--- a/qmk_cli/helpers.py
+++ b/qmk_cli/helpers.py
@@ -1,6 +1,6 @@
 """Useful helper functions.
 """
-from milc import cli
+from milc import cli, format_ansi
 
 
 def question(question, boolean=True, default=''):
@@ -18,10 +18,11 @@ def question(question, boolean=True, default=''):
     else:
         answer_key = 'y/n'
 
-    prompt = '*** %s [%s] ' % (question, answer_key)
+    prompt = format_ansi('\n*** %s [%s] ' % (question, answer_key))
 
     while True:
         answer = input(prompt)
+        print()
         if answer == '' and default.lower() == 'y':
             answer = 'y'
         elif answer == '' and default.lower() == 'n':

--- a/qmk_cli/subcommands/clone.py
+++ b/qmk_cli/subcommands/clone.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from milc import cli
-from qmk_cli.git import clone as git_clone
+from qmk_cli.git import git_clone
 
 default_repo = 'qmk_firmware'
 default_fork = 'qmk/' + default_repo
@@ -27,5 +27,4 @@ def clone(cli):
         cli.log.error('Destination already exists: %s', cli.args.destination)
         exit(1)
 
-    success = git_clone(git_url, cli.args.destination, cli.config.clone.branch)
-    exit(0 if success else 1)
+    return git_clone(git_url, cli.args.destination, cli.config.clone.branch)

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -41,7 +41,7 @@ def setup(cli):
         if question(clone_prompt):
             git_url = '/'.join((cli.config.setup.baseurl, cli.args.fork))
             result = clone(git_url, cli.args.home, cli.config.setup.branch)
-            if not result:
+            if result != 0:
                 exit(1)
 
     # Offer to set `user.qmk_home` for them.

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from milc import cli
-from qmk_cli.git import clone
+from qmk_cli.git import git_clone
 from qmk_cli.helpers import question
 
 default_repo = 'qmk_firmware'
@@ -40,7 +40,7 @@ def setup(cli):
         cli.log.error('Could not find qmk_firmware!')
         if question(clone_prompt):
             git_url = '/'.join((cli.config.setup.baseurl, cli.args.fork))
-            result = clone(git_url, cli.args.home, cli.config.setup.branch)
+            result = git_clone(git_url, cli.args.home, cli.config.setup.branch)
             if result != 0:
                 exit(1)
 
@@ -50,11 +50,13 @@ def setup(cli):
         cli.write_config_option('user', 'qmk_home')
 
     # Run `qmk_firmware/bin/qmk doctor` to check the rest of the environment out
-    if cli.args.home.exists():
-        qmk_bin = cli.args.home / 'bin' / 'qmk'
-        doctor_cmd = [sys.executable, str(qmk_bin), 'doctor']
-        if cli.args.yes:
-            doctor_cmd.append('--yes')
-        if cli.args.no:
-            doctor_cmd.append('--no')
-        doctor = subprocess.run(doctor_cmd)
+    qmk_bin = cli.args.home / 'bin/qmk'
+    doctor_cmd = [sys.executable, qmk_bin, 'doctor']
+
+    if cli.args.yes:
+        doctor_cmd.append('--yes')
+
+    if cli.args.no:
+        doctor_cmd.append('--no')
+
+    subprocess.run(doctor_cmd)

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -1,6 +1,7 @@
 """Setup qmk_firmware on your computer.
 """
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -18,11 +19,14 @@ default_branch = 'master'
 @cli.argument('-y', '--yes', arg_only=True, action='store_true', help='Answer yes to all questions')
 @cli.argument('--baseurl', default='https://github.com', help='The URL all git operations start from')
 @cli.argument('-b', '--branch', default=default_branch, help='The branch to clone')
-@cli.argument('destination', default=os.environ['QMK_HOME'], nargs='?', help='The directory to clone to')
+@cli.argument('-H', '--home', default=Path(os.environ['QMK_HOME']), type=Path, help='The location for QMK Firmware. Defaults to %s' % (os.environ['QMK_HOME'],))
 @cli.argument('fork', default=default_fork, nargs='?', help='The qmk_firmware fork to clone')
 @cli.subcommand('Setup your computer for qmk_firmware.')
 def setup(cli):
-    qmk_firmware = Path(cli.args.destination)
+    """Guide the user through setting up their QMK environment.
+    """
+    clone_prompt = 'Would you like to clone {fg_cyan}%s{fg_reset} to {fg_cyan}%s{fg_reset}?' % (cli.args.fork, shlex.quote(str(cli.args.home)))
+    home_prompt = 'Would you like to set {fg_cyan}%s{fg_reset} as your QMK home?' % (shlex.quote(str(cli.args.home)),)
 
     # Sanity checks
     if cli.args.yes and cli.args.no:
@@ -30,30 +34,25 @@ def setup(cli):
         exit(1)
 
     # Check on qmk_firmware, and if it doesn't exist offer to check it out.
-    if (qmk_firmware / 'Makefile').exists():
-        cli.log.info('Found qmk_firmware at %s.', str(qmk_firmware))
+    if (cli.args.home / 'Makefile').exists():
+        cli.log.info('Found qmk_firmware at %s.', str(cli.args.home))
     else:
-        cli.log.error('qmk_firmware not found!')
-        if question('Would you like to clone %s?' % cli.args.fork):
+        cli.log.error('Could not find qmk_firmware!')
+        if question(clone_prompt):
             git_url = '/'.join((cli.config.setup.baseurl, cli.args.fork))
-            clone(git_url, cli.args.destination, cli.config.setup.branch)
+            clone(git_url, cli.args.home, cli.config.setup.branch)
+
+    # Offer to set `user.qmk_home` for them.
+    if cli.args.home != os.environ['QMK_HOME'] and question(home_prompt):
+        cli.config['user']['qmk_home'] = str(cli.args.home)
+        cli.write_config_option('user', 'qmk_home')
 
     # Run `qmk_firmware/bin/qmk doctor` to check the rest of the environment out
-    if qmk_firmware.exists():
-        qmk_bin = qmk_firmware / 'bin' / 'qmk'
+    if cli.args.home.exists():
+        qmk_bin = cli.args.home / 'bin' / 'qmk'
         doctor_cmd = [sys.executable, str(qmk_bin), 'doctor']
         if cli.args.yes:
             doctor_cmd.append('--yes')
         if cli.args.no:
             doctor_cmd.append('--no')
         doctor = subprocess.run(doctor_cmd)
-        if doctor.returncode != 0:
-            cli.log.error('Your build environment is not setup completely.')
-
-            if question('Would you like to run util/qmk_install?'):
-                curdir = os.getcwd()
-                os.chdir(str(qmk_firmware))
-                process = subprocess.run(['util/qmk_install.sh'])
-                os.chdir(curdir)
-                if process.returncode == 0:
-                    cli.log.info('QMK setup complete!')

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -40,11 +40,13 @@ def setup(cli):
         cli.log.error('Could not find qmk_firmware!')
         if question(clone_prompt):
             git_url = '/'.join((cli.config.setup.baseurl, cli.args.fork))
-            clone(git_url, cli.args.home, cli.config.setup.branch)
+            result = clone(git_url, cli.args.home, cli.config.setup.branch)
+            if not result:
+                exit(1)
 
     # Offer to set `user.qmk_home` for them.
     if cli.args.home != os.environ['QMK_HOME'] and question(home_prompt):
-        cli.config['user']['qmk_home'] = str(cli.args.home)
+        cli.config['user']['qmk_home'] = str(cli.args.home.absolute())
         cli.write_config_option('user', 'qmk_home')
 
     # Run `qmk_firmware/bin/qmk doctor` to check the rest of the environment out


### PR DESCRIPTION
Improve how `qmk setup` works by allowing people to specify a destination without specifying a fork. It also offers to set the location for `qmk_firmware` in `user.qmk_home`.

This should make it easier for people who want to put `qmk_firmware` somewhere other than their home directory.