### PR TITLE
Fix CLI not producing any return codes

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -104,4 +104,16 @@ def main():
             sys.exit(1)
 
     # Call the entrypoint
-    milc.cli()
+    return_code = milc.cli()
+
+    if return_code is False:
+        exit(1)
+
+    elif return_code is not True and isinstance(return_code, int):
+        if return_code < 0 or return_code > 255:
+            milc.cli.log.error('Invalid return_code: %d', return_code)
+            exit(255)
+
+        exit(return_code)
+
+    exit(0)


### PR DESCRIPTION
The return code provided by `milc.cli()` is discarded. This adds the same logic as in https://github.com/qmk/qmk_firmware/blob/6499eb6a3c512ded96443649d66274ce1064df0f/bin/qmk#L81-L93 to exit the CLI with the proper return code.