### PR TITLE
Set default answers for clone and home prompts

### DIFF
--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -65,7 +65,7 @@ def setup(cli):
         cli.log.info('Found qmk_firmware at %s.', str(cli.args.home))
     else:
         cli.log.error('Could not find qmk_firmware!')
-        if yesno(clone_prompt):
+        if yesno(clone_prompt, default=True):
             git_url = '/'.join((cli.config.setup.baseurl, cli.args.fork))
 
             if git_clone(git_url, cli.args.home, cli.config.setup.branch):
@@ -74,7 +74,7 @@ def setup(cli):
                 exit(1)
 
     # Offer to set `user.qmk_home` for them.
-    if cli.args.home != os.environ['QMK_HOME'] and yesno(home_prompt):
+    if cli.args.home != os.environ['QMK_HOME'] and yesno(home_prompt, default=True):
         cli.config['user']['qmk_home'] = str(cli.args.home.absolute())
         cli.write_config_option('user', 'qmk_home')
 


### PR DESCRIPTION
Otherwise it looks like:

```
Would you like to clone qmk/qmk_firmware to /home/fauxpark/qmk_firmware?y
```

Now:

```
Would you like to clone qmk/qmk_firmware to /home/fauxpark/qmk_firmware? [Y/n] y
```