### PR TITLE
Path-ify QMK_HOME

### DIFF
--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -74,7 +74,7 @@ def setup(cli):
                 exit(1)
 
     # Offer to set `user.qmk_home` for them.
-    if cli.args.home != os.environ['QMK_HOME'] and yesno(home_prompt):
+    if cli.args.home != Path(os.environ['QMK_HOME']) and yesno(home_prompt):
         cli.config['user']['qmk_home'] = str(cli.args.home.absolute())
         cli.write_config_option('user', 'qmk_home')
 


### PR DESCRIPTION
Prevents `qmk setup` asking if you want to set `QMK_HOME` even if it is already set.