### PR TITLE
Remove unused dev dependencies from setup.py     

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,8 @@ if __name__ == "__main__":
             "appdirs",
             "argcomplete",
             "colorama",
-            "flake8",
             "hjson",
             "milc>=1.0.8",
-            "nose2",
             "pygments",
-            "yapf"
         ],
     )


### PR DESCRIPTION
These are unused in this repo, and including them requires distribution packages
to add the unnecessary dependencies to the dependency graph.