### PR TITLE
Workaround for ANSI colors in Windows cmd

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -34,6 +34,7 @@ def main():
         print('Please upgrade to Python 3.6 or later.')
 
     if 'windows' in platform().lower():
+        os.system("") # workaround for ansi colors - https://stackoverflow.com/a/51524239
         msystem = os.environ.get('MSYSTEM', '')
 
         if 'mingw64' not in sys.executable or 'MINGW64' not in msystem:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Before
![image](https://user-images.githubusercontent.com/16520359/108559918-e2a4c280-72f3-11eb-881a-d29ee834028d.png)


After
![image](https://user-images.githubusercontent.com/16520359/108559829-c143d680-72f3-11eb-9bcc-4278ce4a1e13.png)


Some context on the change - https://stackoverflow.com/a/51524239


This could also go somewhere in milc? or can just bodge somewhere isolated to qmk_distro_msys