### PR TITLE
[MSYS2] Remove explicit setuptools upgrade from build action

### DIFF
--- a/.github/workflows/cli_setup.yml
+++ b/.github/workflows/cli_setup.yml
@@ -53,10 +53,9 @@ jobs:
         update: true
         install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-python-pip
 
-    - name: (MSYS2) Upgrade pip and setuptools and install wheel
+    - name: (MSYS2) Install Python dependencies
       shell: msys2 {0}
       run: |
-        python3 -m pip install --upgrade pip setuptools
         python3 -m pip install wheel
 
     - name: (MSYS2) Install QMK CLI from source


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`mingw-w64-x86_64-python-pip` depends on `mingw-w64-x86_64-python-setuptools` so there is no real need to install them through pip.