### PR TITLE
Add env subcommand

### DIFF
--- a/qmk_cli/subcommands/__init__.py
+++ b/qmk_cli/subcommands/__init__.py
@@ -3,4 +3,5 @@
 We list each subcommand here explicitly because all the reliable ways of searching for modules are slow and delay startup.
 """
 from . import clone  # noqa
+from . import env  # noqa
 from . import setup  # noqa

--- a/qmk_cli/subcommands/env.py
+++ b/qmk_cli/subcommands/env.py
@@ -9,13 +9,18 @@ from milc import cli
 @cli.subcommand('Prints environment information.')
 def env(cli):
     data = {
-        'QMK_HOME' : os.environ.get('QMK_HOME', "")
+        'QMK_HOME': os.environ.get('QMK_HOME', "")
     }
+ 
+    # Now munge the current cli config
+    for key, val in cli.config.general.items():
+        converted_key = 'QMK_' + key.upper()
+        data[converted_key] = val
 
     if cli.args.var:
         # dump out requested arg
         print(data[cli.args.var])
     else:
         # dump out everything
-        for key,val in data.items():
+        for key, val in data.items():
             print(f'{key}="{val}"')

--- a/qmk_cli/subcommands/env.py
+++ b/qmk_cli/subcommands/env.py
@@ -1,17 +1,21 @@
 """Prints environment information.
 """
 import os
+from pathlib import Path
 
 from milc import cli
+from qmk_cli.helpers import is_qmk_firmware
 
 
 @cli.argument('var', default=None, nargs='?', help='Optional variable to query')
 @cli.subcommand('Prints environment information.')
 def env(cli):
+    home = os.environ.get('QMK_HOME', "")
     data = {
-        'QMK_HOME': os.environ.get('QMK_HOME', "")
+        'QMK_HOME': home,
+        'QMK_FIRMWARE': home if is_qmk_firmware(Path(home)) else ""
     }
- 
+
     # Now munge the current cli config
     for key, val in cli.config.general.items():
         converted_key = 'QMK_' + key.upper()

--- a/qmk_cli/subcommands/env.py
+++ b/qmk_cli/subcommands/env.py
@@ -1,0 +1,21 @@
+"""Prints environment information.
+"""
+import os
+
+from milc import cli
+
+
+@cli.argument('var', default=None, nargs='?', help='Optional variable to query')
+@cli.subcommand('Prints environment information.')
+def env(cli):
+    data = {
+        'QMK_HOME' : os.environ.get('QMK_HOME', "")
+    }
+
+    if cli.args.var:
+        # dump out requested arg
+        print(data[cli.args.var])
+    else:
+        # dump out everything
+        for key,val in data.items():
+            print(f'{key}="{val}"')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Needed a way to query the location of `qmk_firmware` for backup purposes. This way potentially allows the folder to be a bit more dynamic than assuming its in home, or sniffing the conf file which downstream processes do not own.

The basic logic to be implemented is `if backup_enabled and qmk_firmware.exists()`, to which might execute before `qmk_setup` has run or without the config file being written.

Right now it just spits out `QMK_HOME` value and the general section of `cli.config`, in a way that partially mimics `go env`. This could be extended to output stuff like the entire contents of `qmk config` or other runtime stuff like the `broken_module_imports` status.