### PR TITLE
Fix: Allow 'config' subcommand for developers even if requirements are missing

### DIFF
--- a/qmk_cli/helpers.py
+++ b/qmk_cli/helpers.py
@@ -1,6 +1,7 @@
 """Useful helper functions.
 """
 import os
+import sys
 from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path
@@ -32,7 +33,10 @@ def broken_module_imports():
     broken_modules = find_broken_requirements('requirements.txt')
     broken_dev_modules = []
     if cli.config.user.developer:
-        if len(sys.argv) == 1 or (len(sys.argv) > 1 and 'config' != sys.argv[1]):
+        args = sys.argv[1:]
+        while args and args[0][0] == '-':
+            del args[0]
+        if not args or args[0] != 'config':
             broken_dev_modules = find_broken_requirements('requirements-dev.txt')
     to_return = [False, False]
 

--- a/qmk_cli/helpers.py
+++ b/qmk_cli/helpers.py
@@ -30,7 +30,10 @@ def broken_module_imports():
     """Make sure we can import all the python modules.
     """
     broken_modules = find_broken_requirements('requirements.txt')
-    broken_dev_modules = find_broken_requirements('requirements-dev.txt') if cli.config.user.developer else []
+    broken_dev_modules = []
+    if cli.config.user.developer:
+        if len(sys.argv) == 1 or (len(sys.argv) > 1 and 'config' != sys.argv[1]):
+            broken_dev_modules = find_broken_requirements('requirements-dev.txt')
     to_return = [False, False]
 
     if broken_modules:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

We want to allow the user to run qmk config so they can turn off dev mode.
Same as with https://github.com/qmk/qmk_firmware/pull/12416.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
