### PR TITLE
Updates for milc 1.4.0

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -14,8 +14,10 @@ import milc
 import milc.subcommand.config  # noqa
 from milc.questions import yesno
 
+from . import __version__
 from .helpers import find_qmk_firmware, is_qmk_firmware
 
+milc.set_metadata(name='QMK CLI', author='QMK', version=__version__)
 milc.EMOJI_LOGLEVELS['INFO'] = '{fg_blue}Ψ{style_reset_all}'
 
 
@@ -56,8 +58,6 @@ def main():
             exit(1)
 
     # Environment setup
-    import qmk_cli
-    milc.cli.version = qmk_cli.__version__
     qmk_firmware = find_qmk_firmware()
     os.environ['QMK_HOME'] = str(qmk_firmware)
     os.environ['ORIG_CWD'] = os.getcwd()

--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -17,7 +17,7 @@ from milc.questions import yesno
 from . import __version__
 from .helpers import find_qmk_firmware, is_qmk_firmware
 
-milc.set_metadata(name='QMK CLI', author='QMK', version=__version__)
+milc.set_metadata(version=__version__)
 milc.EMOJI_LOGLEVELS['INFO'] = '{fg_blue}Ψ{style_reset_all}'
 
 

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -92,7 +92,7 @@ def setup(cli):
     # Run `qmk doctor` to check the rest of the environment out
     color = '--color' if cli.config.general.color else '--no-color'
     unicode = '--unicode' if cli.config.general.unicode else '--no-unicode'
-    doctor_command = [sys.argv[0], color, unicode, 'doctor']
+    doctor_command = [Path(sys.argv[0]).as_posix(), color, unicode, 'doctor']
 
     if cli.args.no:
         doctor_command.append('--no')

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,6 @@ if __name__ == "__main__":
         ],
         python_requires=metadata['requires-python'],
         install_requires=[
-            "appdirs",
-            "argcomplete",
-            "colorama",
             "dotty-dict",
             "flake8",
             "hid",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
             "hid",
             "hjson",
             "jsonschema>=3",
-            "milc>=1.3.0",
+            "milc>=1.4.0",
             "nose2",
             "pygments",
             "pyusb",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
             "colorama",
             "dotty-dict",
             "flake8",
-            "halo",
             "hid",
             "hjson",
             "jsonschema>=3",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
             "colorama",
             "dotty-dict",
             "flake8",
+            "halo",
             "hid",
             "hjson",
             "jsonschema>=3",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Set the CLI version using the new `set_metadata()` function in MILC 1.4.0. `qmk --version` finally returns some useful information!

Also fixed an apparent bug with ZSH on MSYS2; it does not seem to like backslashes (anymore?). Massaging it with Pathlib appears to make it work again.