### PR TITLE
Switch to the qmk-dotty-dict package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             "attrs==21.2.0",
             "colorama==0.4.4",
             "coverage==5.5",
-            "dotty-dict==1.3.0",
+            "qmk-dotty-dict==1.3.0.post1",
             "flake8==3.9.2",
             "halo==0.0.31",
             "hid==1.0.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The dotty-dict package has UTF-8 characters in the metadata, which certain non-UTF8 locales error out on. This switches to a qmk provided package that does not have that problem.
