### PR TITLE
Add LUFA/QMK HID Bootloader support

### DIFF
--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -48,10 +48,10 @@ KNOWN_BOOTLOADERS = {
     ('239A', '000C'): 'caterina: Adafruit Feather 32U4',
     ('239A', '000D'): 'caterina: Adafruit ItsyBitsy 32U4 3v',
     ('239A', '000E'): 'caterina: Adafruit ItsyBitsy 32U4 5v',
-    ('239A', '000E'): 'caterina: Adafruit ItsyBitsy 32U4 5v',
     ('2A03', '0036'): 'caterina: Arduino Leonardo',
     ('2A03', '0037'): 'caterina: Arduino Micro',
-    ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode'
+    ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode',
+    ('03EB', '2067'): 'qmk-hid: HID Bootloader'
 }
 
 

--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -51,7 +51,8 @@ KNOWN_BOOTLOADERS = {
     ('2A03', '0036'): 'caterina: Arduino Leonardo',
     ('2A03', '0037'): 'caterina: Arduino Micro',
     ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode',
-    ('03EB', '2067'): 'qmk-hid: HID Bootloader'
+    ('03EB', '2067'): 'qmk-hid: HID Bootloader',
+    ('03EB', '2045'): 'lufa-ms: LUFA Mass Storage Bootloader'
 }
 
 


### PR DESCRIPTION
## Description

Add support for QMK HID Bootloader detection. 

Mirrors changes from https://github.com/qmk/qmk_firmware/pull/14038