### PR TITLE
Add workflow to rebuild docker image

### DIFF
--- a/.github/workflows/docker-republish.yml
+++ b/.github/workflows/docker-republish.yml
@@ -1,0 +1,35 @@
+name: Rebuild Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  redeploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2.3.2
+      with:
+        python-version: '3.7'
+    - uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+    - name: 'Get Previous tag'
+      id: previoustag
+      uses: "WyriHaximus/github-action-get-previous-tag@v1"
+    - name: Download previous artifact
+      run: |
+        pip download -d "${GITHUB_WORKSPACE}/dist" qmk=="${{ steps.previoustag.outputs.tag }}"
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1.13.0
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - name: Build and Push to Docker Hub
+      uses: docker/build-push-action@v2.9.0
+      with:
+        context: .
+        push: true
+        tags: qmkfm/qmk_cli:latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
Right now, the only way to pick up latest base_container changes be to bump patch which seems unnecessary.

This will then address a few things:
* `qmk_firmware` CI not using the latest dependencies
* bleh workarounds <https://github.com/qmk/qmk_distro_wsl/pull/34> in dependent projects
