### PR TITLE
Bump the 'jsonschema' version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
 	setuptools>=45
 	# qmk_firmware packages
 	hjson
-	jsonschema>=3
+	jsonschema>=4
 	pygments
 	qmk-dotty-dict
 packages = find:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Bump the installed version of jsonschema to >=4 so we have access to the
validator of the latest meta-schema.
As we already request >=3, installations after 2021-11-30 should satisfy
the new requirements.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
