### PR TITLE
Disable use of config for setup|clone

### DIFF
--- a/qmk_cli/subcommands/clone.py
+++ b/qmk_cli/subcommands/clone.py
@@ -11,20 +11,20 @@ default_fork = 'qmk/' + default_repo
 default_branch = 'master'
 
 
-@cli.argument('--baseurl', default='https://github.com', help='The URL all git operations start from (Default: https://github.com)')
-@cli.argument('-b', '--branch', default=default_branch, help='The branch to clone. Default: %s' % default_branch)
-@cli.argument('destination', default=None, nargs='?', help='The directory to clone to. Default: (current directory)')
-@cli.argument('fork', default=default_fork, nargs='?', help='The qmk_firmware fork to clone. Default: %s' % default_fork)
+@cli.argument('--baseurl', arg_only=True, default='https://github.com', help='The URL all git operations start from (Default: https://github.com)')
+@cli.argument('-b', '--branch', arg_only=True, default=default_branch, help='The branch to clone. Default: %s' % default_branch)
+@cli.argument('destination', arg_only=True, default=None, nargs='?', help='The directory to clone to. Default: (current directory)')
+@cli.argument('fork', arg_only=True, default=default_fork, nargs='?', help='The qmk_firmware fork to clone. Default: %s' % default_fork)
 @cli.subcommand('Clone a qmk_firmware fork.')
 def clone(cli):
     if not cli.args.destination:
         cli.args.destination = os.path.join(os.environ['ORIG_CWD'], default_fork.split('/')[-1])
 
     qmk_firmware = Path(cli.args.destination)
-    git_url = '/'.join((cli.config.clone.baseurl, cli.args.fork))
+    git_url = '/'.join((cli.args.baseurl, cli.args.fork))
 
     if qmk_firmware.exists():
         cli.log.error('Destination already exists: %s', cli.args.destination)
         exit(1)
 
-    return git_clone(git_url, cli.args.destination, cli.config.clone.branch)
+    return git_clone(git_url, cli.args.destination, cli.args.branch)

--- a/qmk_cli/subcommands/env.py
+++ b/qmk_cli/subcommands/env.py
@@ -7,7 +7,7 @@ from milc import cli
 from qmk_cli.helpers import is_qmk_firmware
 
 
-@cli.argument('var', default=None, nargs='?', help='Optional variable to query')
+@cli.argument('var', arg_only=True, default=None, nargs='?', help='Optional variable to query')
 @cli.subcommand('Prints environment information.')
 def env(cli):
     home = os.environ.get('QMK_HOME', "")

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -20,7 +20,7 @@ default_branch = 'master'
 def git_upstream(destination):
     """Add the qmk/qmk_firmware upstream to a qmk_firmware clone.
     """
-    git_url = '/'.join((cli.config.setup.baseurl, default_fork))
+    git_url = '/'.join((cli.args.baseurl, default_fork))
     git_cmd = [
         'git',
         '-C',
@@ -45,10 +45,10 @@ def git_upstream(destination):
 
 @cli.argument('-n', '--no', arg_only=True, action='store_true', help='Answer no to all questions')
 @cli.argument('-y', '--yes', arg_only=True, action='store_true', help='Answer yes to all questions')
-@cli.argument('--baseurl', default=default_base, help='The URL all git operations start from. Default: %s' % default_base)
-@cli.argument('-b', '--branch', default=default_branch, help='The branch to clone. Default: %s' % default_branch)
-@cli.argument('-H', '--home', default=Path(os.environ['QMK_HOME']), type=Path, help='The location for QMK Firmware. Default: %s' % os.environ['QMK_HOME'])
-@cli.argument('fork', default=default_fork, nargs='?', help='The qmk_firmware fork to clone. Default: %s' % default_fork)
+@cli.argument('--baseurl', arg_only=True, default=default_base, help='The URL all git operations start from. Default: %s' % default_base)
+@cli.argument('-b', '--branch', arg_only=True, default=default_branch, help='The branch to clone. Default: %s' % default_branch)
+@cli.argument('-H', '--home', arg_only=True, default=Path(os.environ['QMK_HOME']), type=Path, help='The location for QMK Firmware. Default: %s' % os.environ['QMK_HOME'])
+@cli.argument('fork', arg_only=True, default=default_fork, nargs='?', help='The qmk_firmware fork to clone. Default: %s' % default_fork)
 @cli.subcommand('Setup your computer for qmk_firmware.')
 def setup(cli):
     """Guide the user through setting up their QMK environment.
@@ -77,9 +77,9 @@ def setup(cli):
     else:
         cli.log.error('Could not find qmk_firmware!')
         if yesno(clone_prompt):
-            git_url = '/'.join((cli.config.setup.baseurl, cli.args.fork))
+            git_url = '/'.join((cli.args.baseurl, cli.args.fork))
 
-            if git_clone(git_url, cli.args.home, cli.config.setup.branch):
+            if git_clone(git_url, cli.args.home, cli.args.branch):
                 git_upstream(cli.args.home)
             else:
                 exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
User on discord was confused over why setting `setup.fork` did not work (code would have to be updated to use the alternative location `cli.config.setup.fork`). The assumption begins with items in `qmk config -a` being valid config options.

Doesnt seem to make much sense having config options for setup and clone? The current mixture of args and config just seems to be more complicated than it needs to be because of it.