### PR TITLE
Revert dependency on qmk-dotty-dict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,11 +41,11 @@ install_requires =
 	pyusb
 	setuptools>=45
 	# qmk_firmware packages
+	dotty-dict
 	hjson
 	jsonschema>=4
-	pygments
-	qmk-dotty-dict
 	pillow
+	pygments
 packages = find:
 python_requires = >=3.7
 


### PR DESCRIPTION
https://github.com/msys2/MINGW-packages/pull/11635 (seems to be the recommended method of installing Python packages in MSYS2)
https://github.com/pawelzny/dotty_dict/pull/87 (needs merge + release)

qmk_firmware MSYS2 install script will also need to be updated to install the MSYS2 Python packages.