### PR TITLE
Run `qmk doctor` in the correct directory

### DIFF
--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -104,4 +104,4 @@ def setup(cli):
         if cli.args.yes:
             doctor_command.append('-y')
 
-        cli.run(doctor_command, stdin=None, capture_output=False)
+        cli.run(doctor_command, stdin=None, capture_output=False, cwd=cli.args.home)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
If a user...
1. Already has a valid home setup
2. Chooses to run `qmk setup` with a "new" home
3. Does not set home when prompted

`qmk doctor` is incorrectly run in the original home, rather than the new.