### PR TITLE
Formatting fix.

### DIFF
--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -141,8 +141,8 @@ class MonitorDevice(object):
                 identifier = (int2hex(message['vendor_id']), int2hex(message['product_id'])) if self.numeric else (message['manufacturer_string'], message['product_string'])
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
-
-                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message.replace('%', '%%'))
+                message['text'] = message['text'].replace('%', '%%')
+                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
 
             except self.hid.HIDException:
                 break

--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -142,7 +142,7 @@ class MonitorDevice(object):
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
                 message['text'] = message['text'].replace('%', '%%')
-                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s', **message)
+                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
 
             except self.hid.HIDException:
                 break

--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -141,8 +141,8 @@ class MonitorDevice(object):
                 identifier = (int2hex(message['vendor_id']), int2hex(message['product_id'])) if self.numeric else (message['manufacturer_string'], message['product_string'])
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
-                message['text'] = message['text'].replace('%', '%%')
-                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
+
+                cli.echo('%s', '%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
 
             except self.hid.HIDException:
                 break

--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -141,8 +141,7 @@ class MonitorDevice(object):
                 identifier = (int2hex(message['vendor_id']), int2hex(message['product_id'])) if self.numeric else (message['manufacturer_string'], message['product_string'])
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
-                message['text'] = message['text'].replace('%', '%%')
-                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
+                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s', **message)
 
             except self.hid.HIDException:
                 break

--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -142,7 +142,7 @@ class MonitorDevice(object):
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
 
-                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
+                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message.replace('%', '%%'))
 
             except self.hid.HIDException:
                 break

--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -141,6 +141,7 @@ class MonitorDevice(object):
                 identifier = (int2hex(message['vendor_id']), int2hex(message['product_id'])) if self.numeric else (message['manufacturer_string'], message['product_string'])
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
+                message['text'] = message['text'].replace('%', '%%')
                 cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s', **message)
 
             except self.hid.HIDException:


### PR DESCRIPTION
## Description

Seems including a `%` in the console output throws errors.

See https://github.com/qmk/qmk_firmware/pull/20238

Seems like a potential bug in `milc` but we don't have access to that.

Tested using:
```sh
python3 -m pip uninstall -y qmk
python3 -m pip install git+https://github.com/qmk/qmk_cli.git@attempted-formatting-fix
```