### PR TITLE
feat: wb32 bootloader

### DIFF
--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -52,7 +52,8 @@ KNOWN_BOOTLOADERS = {
     ('239A', '000E'): 'caterina: Adafruit ItsyBitsy 32U4 5v',
     ('2A03', '0036'): 'caterina: Arduino Leonardo',
     ('2A03', '0037'): 'caterina: Arduino Micro',
-    ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode'
+    ('314B', '0106'): 'apm32-dfu: APM32 DFU ISP Mode',
+    ('342D', 'DFA0'): 'wb32-dfu: WB32 Device in DFU Mode'
 }
 
 


### PR DESCRIPTION
## Description

Add WB32 bootloader to `qmk_console`.