### PR TITLE
Automatically configure userspace at runtime

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -13,7 +13,7 @@ from traceback import print_exc
 import milc
 
 from . import __version__
-from .helpers import find_qmk_firmware, is_qmk_firmware
+from .helpers import find_qmk_firmware, is_qmk_firmware, find_qmk_userspace, is_qmk_userspace
 
 milc.cli.milc_options(version=__version__)
 milc.EMOJI_LOGLEVELS['INFO'] = '{fg_blue}Ψ{style_reset_all}'
@@ -59,7 +59,9 @@ def main():
             exit(1)
 
     # Environment setup
+    qmk_userspace = find_qmk_userspace()
     qmk_firmware = find_qmk_firmware()
+    os.environ['QMK_USERSPACE'] = str(qmk_userspace)
     os.environ['QMK_HOME'] = str(qmk_firmware)
     os.environ['ORIG_CWD'] = os.getcwd()
 

--- a/qmk_cli/subcommands/env.py
+++ b/qmk_cli/subcommands/env.py
@@ -4,16 +4,18 @@ import os
 from pathlib import Path
 
 from milc import cli
-from qmk_cli.helpers import is_qmk_firmware
+from qmk_cli.helpers import is_qmk_firmware, is_qmk_userspace
 
 
 @cli.argument('var', arg_only=True, default=None, nargs='?', help='Optional variable to query')
 @cli.subcommand('Prints environment information.')
 def env(cli):
     home = os.environ.get('QMK_HOME', "")
+    userspace = os.environ.get('QMK_USERSPACE', "")
     data = {
         'QMK_HOME': home,
-        'QMK_FIRMWARE': home if is_qmk_firmware(Path(home)) else ""
+        'QMK_FIRMWARE': home if is_qmk_firmware(Path(home)) else "",
+        'QMK_USERSPACE': userspace if is_qmk_userspace(Path(userspace)) else ""
     }
 
     # Now munge the current cli config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

* Removes the requirement on running `qmk config user.overlay_dir="$(realpath qmk_userspace)"` 
* Allows multiple userspace instances by inferring from the current directory
* Adds `qmk env QMK_USERSPACE` for scripting purposes