### PR TITLE
qmk console: dprintf() not getting colored

### DIFF
--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -143,7 +143,7 @@ class MonitorDevice(object):
                 message['identifier'] = ':'.join(identifier)
                 message['ts'] = '{style_dim}{fg_green}%s{style_reset_all} ' % (strftime(cli.config.general.datetime_fmt),) if cli.args.timestamp else ''
 
-                cli.echo('%s', '%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
+                cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
 
             except self.hid.HIDException:
                 break


### PR DESCRIPTION
When getting debug output from my keyboard using `qmk console`, The output from `dprintf()` wasn't getting colored, leaving `{fg_blue}` and `{style_reset_all}` tags behind and cluttering up 


## Description
```py
cli.echo('%s', '%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
```
removing the first  '%s',  seems to fix the issue
```py
cli.echo('%(ts)s%(color)s%(identifier)s:%(index)d{style_reset_all}: %(text)s' % message)
```

### Broken
![broke](https://github.com/qmk/qmk_cli/assets/124642739/07561802-5a00-4548-8a0f-5b79216e4df9)
![broke-fn](https://github.com/qmk/qmk_cli/assets/124642739/a94cd70b-efc4-4476-9753-51becc2d0aee)
### Fixed
![fix](https://github.com/qmk/qmk_cli/assets/124642739/8d42a348-181e-4506-940a-7844a076d300)
![fix-fn](https://github.com/qmk/qmk_cli/assets/124642739/0f12d564-637a-46c7-84ec-41723757b286)
