### PR TITLE
Bump minimum python version to 3.9

### DIFF
--- a/.github/workflows/cli_setup.yml
+++ b/.github/workflows/cli_setup.yml
@@ -32,7 +32,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        include:
+          - os: macos-13
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v4
@@ -59,16 +62,17 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-pillow mingw-w64-x86_64-rust
+        install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-build mingw-w64-x86_64-python-pillow mingw-w64-x86_64-rust
 
+    # Upgrade pip due to msys packaging + pypa/build/pull/736 issues
     - name: (MSYS2) Install Python dependencies
       shell: msys2 {0}
       run: |
-        python3 -m pip install -U setuptools wheel
+        python3 -m pip install --upgrade pip
+
     - name: (MSYS2) Install QMK CLI from source
       shell: msys2 {0}
       run: |
-        python3 -m pip install -U build
         python3 -m build
         python3 -m pip install dist/qmk-*.tar.gz
     - name: (MSYS2) Run qmk setup -y

--- a/.github/workflows/docker-republish.yml
+++ b/.github/workflows/docker-republish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.9'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.9'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -46,9 +46,9 @@ def main():
     """Setup the environment before dispatching to the entrypoint.
     """
     # Warn if they use an outdated python version
-    if sys.version_info < (3, 7):
+    if sys.version_info < (3, 9):
         print('Warning: Your Python version is out of date! Some subcommands may not work!')
-        print('Please upgrade to Python 3.7 or later.')
+        print('Please upgrade to Python 3.9 or later.')
 
     if 'windows' in platform().lower():
         msystem = os.environ.get('MSYSTEM', '')

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
 	pygments
 	pyserial
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

From https://github.com/qmk/qmk_firmware/pull/23989

```py
# Last update: 2024 Jun 24
#
# Arch: 3.12
# Debian 11: 3.9
# Debian 12: 3.11
# Fedora 39: 3.12
# Fedora 40: 3.12
# FreeBSD: 3.11
# Gentoo: 3.12
# macOS: 3.12 (from homebrew)
# msys2: 3.11
# Slackware: 3.9
# solus: 3.10
# Ubuntu 22.04: 3.10
# Ubuntu 24.04: 3.12
# void: 3.12
```

Notes:

* macos runners are unable to install the older versions of python
* Single x64 macos job has been added now `macos-latest` points to Arm64
* Fixed windows execution
  * pypa/build#736 now attempts to use system `pip`
  * msys2 packaging strips out some of the required dependencies <https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python-pip/PKGBUILD#L38>
  * Bodge reinstall of pip via pypi with the required files 