### PR TITLE
Adjust format string for could-not-connect message in console

### DIFF
--- a/qmk_cli/subcommands/console.py
+++ b/qmk_cli/subcommands/console.py
@@ -184,7 +184,7 @@ class FindDevices(object):
                         except Exception as e:
                             device['e'] = e
                             device['e_name'] = e.__class__.__name__
-                            cli.log.error("Could not connect to %(color)s%(manufacturer_string)s %(product_string)s{style_reset_all} (%(color)s:%(vendor_id)04X:%(product_id)04X:%(index)d): %(e_name)s: %(e)s", device)
+                            cli.log.error("Could not connect to %(color)s%(manufacturer_string)s %(product_string)s{style_reset_all} (%(color)s%(vendor_id)04X:%(product_id)04X:%(index)d{style_reset_all}): %(e_name)s: %(e)s", device)
                             if cli.config.general.verbose:
                                 cli.log.exception(e)
                             del live_devices[device['path']]


### PR DESCRIPTION
I've noticed a slight inconsistency in the messages output by `qmk console`.

## Description

Adjust the format string for the error message printed when `qmk console` cannot connect to the device.

Before:
![Screenshot-2024-09-09-205712](https://github.com/user-attachments/assets/f6b896fe-cce4-4089-bbee-e0edf18e4e17)

After:
![Screenshot-2024-09-09-210215](https://github.com/user-attachments/assets/195356ce-2d19-4a05-a158-413afa218882)
(notice the changes around the device ID and detailed error message at the end)
