### PR TITLE
setup.cfg: drop setuptools dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
 	hid
 	milc>=1.9.0
 	pyusb
-	setuptools>=45
 	# qmk_firmware packages
 	dotty-dict
 	hjson


### PR DESCRIPTION
This fixes the following bug in Debian:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1083736

## Description

The setuptools dependency is not needed in this file because setuptools will be installed from the pyproject.toml file. Since the project does not use anything from the setuptools package, remove it as a dependency.
