### PR TITLE
Align order of userspace search

### DIFF
--- a/qmk_cli/helpers.py
+++ b/qmk_cli/helpers.py
@@ -81,14 +81,14 @@ def find_qmk_userspace():
     if in_qmk_userspace():
         return in_qmk_userspace()
 
-    if cli.config.user.overlay_dir:
-        return Path(cli.config.user.overlay_dir).expanduser().resolve()
-
     if 'QMK_USERSPACE' in os.environ:
         path = Path(os.environ['QMK_USERSPACE']).expanduser()
         if path.exists():
             return path.resolve()
         return path
+
+    if cli.config.user.overlay_dir:
+        return Path(cli.config.user.overlay_dir).expanduser().resolve()
 
     return Path.home() / 'qmk_userspace'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
#168 added support for automatically configuring userspace, however the order used for search does not match that of `qmk_firmware`.

If both config and environment variable are configured at the same time, you can get into a scenario where the wrong userspace directory is used, causing confusion and unexpected compilation results.