### PR TITLE
Fix relative paths if qmk_firmware exists elsewhere

### DIFF
--- a/qmk_cli/helpers.py
+++ b/qmk_cli/helpers.py
@@ -8,6 +8,16 @@ from pathlib import Path
 from milc import cli
 
 
+def AbsPath(arg):
+    """Resolve relative paths to the original working directory.
+    """
+    arg = Path(arg)
+    if not arg.is_absolute():
+        return (Path(os.environ['ORIG_CWD']) / arg).absolute()
+
+    return arg
+
+
 def is_qmk_firmware(qmk_firmware):
     """Returns True if the given Path() is a qmk_firmware clone.
     """

--- a/qmk_cli/subcommands/clone.py
+++ b/qmk_cli/subcommands/clone.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from milc import cli
 from qmk_cli.git import git_clone
+from qmk_cli.helpers import AbsPath
 
 default_repo = 'qmk_firmware'
 default_fork = 'qmk/' + default_repo
@@ -13,18 +14,14 @@ default_branch = 'master'
 
 @cli.argument('--baseurl', arg_only=True, default='https://github.com', help='The URL all git operations start from (Default: https://github.com)')
 @cli.argument('-b', '--branch', arg_only=True, default=default_branch, help='The branch to clone. Default: %s' % default_branch)
-@cli.argument('destination', arg_only=True, default=None, nargs='?', help='The directory to clone to. Default: (current directory)')
+@cli.argument('destination', arg_only=True, default=Path(os.environ['ORIG_CWD']) / default_repo, type=AbsPath, nargs='?', help='The directory to clone to. Default: (current directory)')
 @cli.argument('fork', arg_only=True, default=default_fork, nargs='?', help='The qmk_firmware fork to clone. Default: %s' % default_fork)
 @cli.subcommand('Clone a qmk_firmware fork.')
 def clone(cli):
-    if not cli.args.destination:
-        cli.args.destination = os.path.join(os.environ['ORIG_CWD'], default_fork.split('/')[-1])
-
-    qmk_firmware = Path(cli.args.destination)
     git_url = '/'.join((cli.args.baseurl, cli.args.fork))
 
     # Exists (but not an empty dir)
-    if qmk_firmware.exists() and any(qmk_firmware.iterdir()):
+    if cli.args.destination.exists() and any(cli.args.destination.iterdir()):
         cli.log.error('Destination already exists: %s', cli.args.destination)
         exit(1)
 

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -10,7 +10,7 @@ from shutil import rmtree
 from milc import cli
 from milc.questions import choice, question, yesno
 from qmk_cli.git import git_clone
-from qmk_cli.helpers import is_qmk_firmware
+from qmk_cli.helpers import AbsPath, is_qmk_firmware
 
 default_base = 'https://github.com'
 default_repo = 'qmk_firmware'
@@ -59,7 +59,7 @@ def git_clone_fork(fork, branch, force=False):
 @cli.argument('-y', '--yes', arg_only=True, action='store_true', help='Answer yes to all questions')
 @cli.argument('--baseurl', arg_only=True, default=default_base, help='The URL all git operations start from. Default: %s' % default_base)
 @cli.argument('-b', '--branch', arg_only=True, default=default_branch, help='The branch to clone. Default: %s' % default_branch)
-@cli.argument('-H', '--home', arg_only=True, default=Path(os.environ['QMK_HOME']), type=Path, help='The location for QMK Firmware. Default: %s' % os.environ['QMK_HOME'])
+@cli.argument('-H', '--home', arg_only=True, default=Path(os.environ['QMK_HOME']), type=AbsPath, help='The location for QMK Firmware. Default: %s' % os.environ['QMK_HOME'])
 @cli.argument('fork', arg_only=True, default=default_fork, nargs='?', help='The qmk_firmware fork to clone. Default: %s' % default_fork)
 @cli.subcommand('Setup your computer for qmk_firmware.')
 def setup(cli):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

When an existing `qmk_firmware` directory exists, the following code happens,

https://github.com/qmk/qmk_cli/blob/36c23e3de621105b02e8a345de6bcc72cfcf0598/qmk_cli/script_qmk.py#L83-L86

This changes the current directory, which in turn changes the context for where relative paths resolve. For both setup and clone this can cause clones to the wrong location.

Steps to reproduce:
1. Have a valid `qmk_firmware` configured, eg the default of `/home/<user>/qmk_firmware/`
2. Change current directory somewhere empty, eg `mkdir /tmp/asdf/ && cd /tmp/asdf/`
2. Run `qmk setup -H ./`
3. Note how cli declares it has found a valid directory and prompts to reinstall/continue