### PR TITLE
Only set userspace if valid.

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -13,7 +13,7 @@ from traceback import print_exc
 import milc
 
 from . import __version__
-from .helpers import find_qmk_firmware, is_qmk_firmware, find_qmk_userspace
+from .helpers import find_qmk_firmware, is_qmk_firmware, find_qmk_userspace, is_qmk_userspace
 
 milc.cli.milc_options(version=__version__)
 milc.EMOJI_LOGLEVELS['INFO'] = '{fg_blue}Ψ{style_reset_all}'
@@ -73,7 +73,10 @@ def main():
     # Environment setup
     qmk_userspace = find_qmk_userspace()
     qmk_firmware = find_qmk_firmware()
-    os.environ['QMK_USERSPACE'] = str(qmk_userspace)
+    if is_qmk_userspace(qmk_userspace):
+        os.environ['QMK_USERSPACE'] = str(qmk_userspace)
+    elif 'QMK_USERSPACE' in os.environ:  # Failed to find valid userspace, including what was in the environment if specified -- wipe any environment variable if present as it's clearly invalid.
+        os.environ.pop('QMK_USERSPACE')
     os.environ['QMK_HOME'] = str(qmk_firmware)
     os.environ['ORIG_CWD'] = os.getcwd()
 


### PR DESCRIPTION
## Description

As per the title. Configurator seems to try to copy to `$HOME/qmk_userspace` if not explicitly set.