### PR TITLE
fix: handle broken pipe when printing env vars

### DIFF
--- a/qmk_cli/subcommands/env.py
+++ b/qmk_cli/subcommands/env.py
@@ -25,10 +25,13 @@ def env(cli):
         converted_key = 'QMK_' + key.upper()
         data[converted_key] = val
 
-    if cli.args.var:
-        # dump out requested arg
-        print(data[cli.args.var])
-    else:
-        # dump out everything
-        for key, val in data.items():
-            print(f'{key}="{val}"')
+    try:
+        if cli.args.var:
+            # dump out requested arg
+            print(data[cli.args.var])
+        else:
+            # dump out everything
+            for key, val in data.items():
+                print(f'{key}="{val}"')
+    except BrokenPipeError:
+        return


### PR DESCRIPTION
Fixes #228

`qmk env` can raise `BrokenPipeError` when stdout is closed early, and that bubbles up into a noisy traceback during commands like `qmk clean` that call it internally. This catches `BrokenPipeError` in the env output path and exits that subcommand cleanly.

Greetings, saschabuehrle