### PR TITLE
Remove Windows environment checks

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -73,27 +73,6 @@ def main():
         print('Warning: Your Python version is out of date! Some subcommands may not work!')
         print('Please upgrade to Python 3.9 or later.')
 
-    if 'windows' in platform().lower():
-        msystem = os.environ.get('MSYSTEM', '')
-
-        # Assume the environment isn't workable by default
-        env_ok = False
-
-        # Check if we're using the mingw64/msys2 environment
-        if 'mingw64' in sys.executable and 'MINGW64' in msystem:
-            env_ok = True
-
-        # Check if we're using a `uv`-based environment
-        if '\\uv\\' in sys.executable or '/uv/' in sys.executable:
-            env_ok = True
-
-        # If none of the options above were true, then we're in an unsupported environment. Bomb out.
-        if not env_ok:
-            print('ERROR: It seems you are not using the MINGW64 terminal.')
-            print('Please close this terminal and open a new MSYS2 MinGW 64-bit terminal.')
-            print('Python: %s, MSYSTEM: %s' % (sys.executable, msystem))
-            exit(1)
-
     # Environment setup
     qmk_userspace = find_qmk_userspace()
     qmk_firmware = find_qmk_firmware()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Windows checks are currently failing when running under msys ucrt64 and not using uv (QMK MSYS cannot use uv due to it not currently being portable).

As discussed, these checks do not add a lot of value when considering the current recommended install methods. 