### PR TITLE
Handle errors on Windows where some of the files have their read-only bit set

### DIFF
--- a/qmk_cli/helpers.py
+++ b/qmk_cli/helpers.py
@@ -1,7 +1,10 @@
 """Useful helper functions.
 """
 import os
+import sys
+import stat
 import json
+import shutil
 from functools import lru_cache
 from pathlib import Path
 
@@ -16,6 +19,20 @@ def AbsPath(arg):  # noqa: N802
         return (Path(os.environ['ORIG_CWD']) / arg).absolute()
 
     return arg
+
+
+def rmtree(path):
+    """Safe version of shutil.rmtree which handles errors on Windows where some of the files have their read-only bit set."""
+    def remove_readonly(func, path, _):
+        """Clear the readonly bit and reattempt the removal."""
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
+    if sys.version_info >= (3, 12):
+        # See https://docs.python.org/3.12/whatsnew/3.12.html#shutil
+        return shutil.rmtree(path, onexc=remove_readonly)
+    else:
+        return shutil.rmtree(path, onerror=remove_readonly)
 
 
 def is_qmk_firmware(qmk_firmware):

--- a/qmk_cli/subcommands/setup.py
+++ b/qmk_cli/subcommands/setup.py
@@ -5,12 +5,11 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
-from shutil import rmtree
 
 from milc import cli
 from milc.questions import choice, question, yesno
 from qmk_cli.git import git_clone
-from qmk_cli.helpers import AbsPath, is_qmk_firmware
+from qmk_cli.helpers import AbsPath, is_qmk_firmware, rmtree
 
 default_base = 'https://github.com'
 default_repo = 'qmk_firmware'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

There have been a few reports that match the following error <https://discord.com/channels/440868230475677696/473506116718952450/1512583411104223296>.

This adds a workaround based on the suggestion in the [python docs](https://docs.python.org/3.12/library/shutil.html#rmtree-example).