### PR TITLE
Avoid computing `_get_default_distrib_path` when QMK_DISTRIB_DIR is set

### DIFF
--- a/qmk_cli/script_qmk.py
+++ b/qmk_cli/script_qmk.py
@@ -31,7 +31,7 @@ def _get_default_distrib_path():
 
 
 # Ensure the QMK distribution is on the `$PATH` if present. This must be kept in sync with qmk/qmk_firmware.
-QMK_DISTRIB_DIR = Path(os.environ.get('QMK_DISTRIB_DIR', _get_default_distrib_path()))
+QMK_DISTRIB_DIR = Path(os.environ['QMK_DISTRIB_DIR'] if 'QMK_DISTRIB_DIR' in os.environ else _get_default_distrib_path())
 if QMK_DISTRIB_DIR.exists():
     os.environ['PATH'] = str(QMK_DISTRIB_DIR / 'bin') + os.pathsep + os.environ['PATH']
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Keeping in line with qmk/qmk_firmware#26339.

Avoids extra overhead during initialisation of CLI.